### PR TITLE
Fix documentation and FireSim config names

### DIFF
--- a/firesim-collateral/README.md
+++ b/firesim-collateral/README.md
@@ -1,20 +1,20 @@
 # Using NVDLA with FireSim
 
-To build an NVDLA FPGA image on FireSim, please use the ``nvdla_config_build_recipes.ini` file when running the ``firesim buildafi`` command.
+To build an NVDLA FPGA image on FireSim, please use the `nvdla_config_build_recipes.ini` file when running the `firesim buildafi` command.
 
-First, change your ``config\_build.ini`` file to include the name(s) of the recipes you want to build an FPGA AFI for.
+First, change your `config_build.ini` file to include the name(s) of the recipes you want to build an FPGA AFI for.
 
 ```
 [builds]
 # other build recipes
-firesim-rocket-singlecore-small-nvdla-no-nic-l2-llc4mb-ddr3
+firesim-rocket-quadcore-small-nvdla-no-nic-l2-llc4mb-ddr3
 # other build recipes
 ```
 
-Then point to the build recipe file when running the ``buildafi`` command and all future FireSim commands.
+Then point to the build recipe file when running the `buildafi` command and all future FireSim commands.
 
 ```
-firesim buildafi -r $NVDLA_DIR/firesim-collateral/nvdla_config_build_recipes.ini``
+firesim buildafi -r $NVDLA_DIR/firesim-collateral/nvdla_config_build_recipes.ini
 ```
 
 ## Disclaimer

--- a/firesim-collateral/nvdla_config_build_recipes.ini
+++ b/firesim-collateral/nvdla_config_build_recipes.ini
@@ -1,13 +1,13 @@
-# Single-core, Rocket-based recipes with Small NVDLA
-[firesim-rocket-singlecore-small-nvdla-no-nic-l2-llc4mb-ddr3]
+# Quad-core, Rocket-based recipes with Small NVDLA
+[firesim-rocket-quadcore-small-nvdla-no-nic-l2-llc4mb-ddr3]
 DESIGN=FireSim
 TARGET_CONFIG=WithNVDLASmall_DDR3FRFCFSLLC4MB_FireSimQuadRocketConfig
 PLATFORM_CONFIG=F75MHz_BaseF1Config
 instancetype=z1d.2xlarge
 deploytriplet=None
 
-# Single-core, Rocket-based recipes with Large NVDLA
-[firesim-rocket-singlecore-large-nvdla-no-nic-l2-llc4mb-ddr3]
+# Quad-core, Rocket-based recipes with Large NVDLA
+[firesim-rocket-quadcore-large-nvdla-no-nic-l2-llc4mb-ddr3]
 DESIGN=FireSim
 TARGET_CONFIG=WithNVDLALarge_DDR3FRFCFSLLC4MB_FireSimQuadRocketConfig
 PLATFORM_CONFIG=F50MHz_BaseF1Config


### PR DESCRIPTION
I mostly just changed the FireSim config names to reflect that there are four Rocket cores in these configs, not one. Also made some minor Markdown syntax fixes.